### PR TITLE
Changes the GitHub button to redirect to the current codebase.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -59,7 +59,7 @@
 	var/wikiurl = "http://www.tgstation13.org/wiki" // Default wiki link.
 	var/forumurl = "http://tgstation13.org/phpBB/index.php" //default forums
 	var/rulesurl = "http://www.tgstation13.org/wiki/Rules" // default rules
-	var/githuburl = "https://www.github.com/tgstation/-tg-station" //default github
+	var/githuburl = "https://github.com/Citadel-Station-13/Citadel-Station-13-4th-Port" //Changes github to redirect to the Citadel Station Git
 
 	var/forbid_singulo_possession = 0
 	var/useircbot = 0


### PR DESCRIPTION
Just a quick fix, due to people wondering where they could find the Citadel Station 13 GitHub and being directed to /TG/ when they clicked the "GitHub" button